### PR TITLE
typo in url

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -112,6 +112,6 @@ entries:
       name: goshelly-server
       type: application
       urls:
-        - https://araalinetworks.github.io/araali-helm/charts/goshelly-server-0.1.0.tgz
+        - https://araalinetworks.github.io/araali-helm/charts/goshelly/goshelly-server-0.1.0.tgz
       version: 0.1.0
 generated: "2022-09-12T16:10:51.916912036Z"


### PR DESCRIPTION
Tried deploying Goshelly in Araali clusters, realized I had a locally fixed issue not committed here.